### PR TITLE
Modified entries yield

### DIFF
--- a/bin/asngen.py
+++ b/bin/asngen.py
@@ -50,8 +50,7 @@ class ASNGenCommand(GeneratingCommand):
 
         for name in zipfile.namelist():
             entries = re.findall(r'^(\d+\.\d+\.\d+\.\d+)\/(\d+),(\d+),\"?([^\"\n]+)\"?', zipfile.open(name).read(), re.MULTILINE)
-
-        for line in entries:
-            yield {'ip': line[0] + "/" + line[1], 'asn': line[2], 'autonomous_system': line[3].decode('utf-8', 'ignore')}
+            for line in entries:
+                yield {'ip': line[0] + "/" + line[1], 'asn': line[2], 'autonomous_system': line[3].decode('utf-8', 'ignore')}
 
 dispatch(ASNGenCommand, sys.argv, sys.stdin, sys.stdout, __name__)


### PR DESCRIPTION
Modified where the for-loop for yielding the ASN information takes place. This is since the other method will only actually yield data for the last file put into "entries", which with the change in the download is an issue.

This should fix the problems folks are seeing in #9, where nothing is being yielded into Splunk when you run this command. Based on a test run I had done, it appears "COPYRIGHT.TXT" was the last file parsed.

