### PR TITLE
Max mind change20191230

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 ASN Lookup Generator for Splunk
 
 Further documentation is provided in the wiki here: https://github.com/doksu/TA-asngen/wiki
+
+To download the ASN data from MaxMind, an account (free) with MaxMind is required and a valid license key (free).

--- a/default/app.conf
+++ b/default/app.conf
@@ -8,7 +8,7 @@ label = ASN Lookup Generator
 [launcher]
 author = doksu
 description = ASN Lookup Generator
-version = 1.0.1
+version = 1.0.2
 
 [package]
 id = TA-asngen

--- a/default/asngen.conf
+++ b/default/asngen.conf
@@ -1,2 +1,5 @@
 [proxies]
 https =
+
+[maxmind]
+license_key =

--- a/default/limits.conf
+++ b/default/limits.conf
@@ -1,0 +1,2 @@
+[lookup]
+max_memtable_bytes=30000000

--- a/default/setup.xml
+++ b/default/setup.xml
@@ -10,4 +10,13 @@
 			<type>text</type>
 		</input>
 	</block>
+
+	<block title="MaxMind License" endpoint="configs/conf-asngen" entity="maxmind">
+        	<text>Enter your MaxMind license key.</text>
+		<input field="license_key">
+			<label>license key</label>
+			<type>text</type>
+		</input>
+	</block>
+
 </setup>


### PR DESCRIPTION
The old way to access the MaxMind GeoLite2 databases no longer works as of 2019-Dec-30.
Now a (free) registration and license key is required.

I have updated the app to work with this new way of accessing the databases.
To do so, there is now a new configuration item (the license key).

The docs propose a required setting for limits.conf. The second commit adds this directly to the app. Less errors and scratching your head for splunk> admins who fail to read the docs and do the update.