### PR TITLE
ignore local metadata file in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 local
+metadata/local.meta


### PR DESCRIPTION
The files in local/ are already ignored. Setting different
permissions, however, is in metadata/local.meta, so that
file should also be ignored.