### PR TITLE
Fix for shcluster

### DIFF
--- a/bin/asngen.py
+++ b/bin/asngen.py
@@ -21,7 +21,10 @@ class ASNGenCommand(GeneratingCommand):
 
         try:
             configparser = ConfigParser.ConfigParser()
-            configparser.read(os.path.join(os.environ['SPLUNK_HOME'], 'etc/apps/TA-asngen/local/asngen.conf'))
+            # first try to read the defaults (in case we are in a cluster with deployed config)
+            configparser.read(os.path.join(os.getcwd(), '../default/asngen.conf'))
+            # then try to read the overrides
+            configparser.read(os.path.join(os.getcwd(), '../local/asngen.conf'))
 
             if configparser.has_section('proxies'):
                 if configparser.has_option('proxies', 'https'):

--- a/default/app.conf
+++ b/default/app.conf
@@ -8,7 +8,7 @@ label = ASN Lookup Generator
 [launcher]
 author = doksu
 description = ASN Lookup Generator
-version = 1.1.0
+version = 1.1.1
 
 [package]
 id = TA-asngen


### PR DESCRIPTION
- On a searchhead cluster, everything in local/ is merged to
  default/ when deploying an app. Therefor checking the config
  file in local/ only will not work in such an installation.
  Get the config from default/ first (if available), then get
  overrides from local/ (if available).
  Addidional info: In a searchhead cluster, the setup screen
  will not work, the configuration must be done manually and
  deployed via the searchhead deployer.

- The path to the asngen.conf file was hardcoded, relative to
  $SPLUNK_HOME. When the app is installed under a different
  name, then reading the config file fails. Change this to
  a completely relative path, based on the current working
  directory, which is the bin/ directory in the ap