### PR TITLE
allow proxy authentication

### DIFF
--- a/bin/asngen.py
+++ b/bin/asngen.py
@@ -48,7 +48,9 @@ class ASNGenCommand(GeneratingCommand):
 
         if proxies['https'] is not None:
             proxy = urllib_functions.ProxyHandler(proxies)
-            opener = urllib_functions.build_opener(proxy)
+            auth = urllib_functions.HTTPBasicAuthHandler()
+            httphandler = urllib_functions.HTTPHandler()
+            opener = urllib_functions.build_opener(proxy, auth, httphandler)
             urllib_functions.install_opener(opener)
 
         if maxmind['license_key'] is None:


### PR DESCRIPTION
solves issue 23

tested by Sumanta88 in and environment with proxy authentication
tested by kurtkeller in and environment without proxy authentication

If you don't need proxy authentication then you'd use an entry like
this in your asngen.conf

[proxies]
http://my_proxy_host:my_proxy_port

If you need proxy authentication then you'd use an entry like this
in your asngen.conf

[proxies]
https =
http://my_proxy_username:my_proxy_password@my_proxy_host:my_proxy_port